### PR TITLE
Pipeline request profiling + fast custom color analysis

### DIFF
--- a/api/pipeline/app/detect.py
+++ b/api/pipeline/app/detect.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import numpy as np
 from flask import Blueprint, jsonify, request
@@ -8,6 +9,7 @@ from app.utils import (
     call_sam3_api,
     decode_image,
     process_pipeline_outputs,
+    timed,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,30 +37,37 @@ def detect():
     """
     try:
         data = request.json
+        profile_enabled = bool(data.get("profile"))
+        timings = {} if profile_enabled else None
+        request_start = time.perf_counter()
+
         state_in = data.get("state", {})
         image_data = data["image_data"]
-        image = decode_image(image_data)
+        with timed(timings, "decode_image"):
+            image = decode_image(image_data)
 
         cleaning_state = state_in.get("cleaning_state")
 
-        _, _, _, pot_state_from_sam3, sorted_pot_masks, _ = detect_pots_sam3(image)
+        with timed(timings, "detect_pots_sam3"):
+            _, _, _, pot_state_from_sam3, sorted_pot_masks, _ = detect_pots_sam3(image)
 
         # For the plant SAM3 request, we want to run mask reconditioning every frame
-        plant_result = call_sam3_api(
-            image,
-            endpoint="detect",
-            text_prompt="plant",
-            recondition_on_trk_masks=False,
-            recondition_every_nth_frame=1,
-            score_threshold_detection=0.165,
-            high_conf_thresh=0.3,
-            high_iou_thresh=0.5,
-            new_det_thresh=0.5,
-            det_nms_thresh=0.5,
-            assoc_iou_thresh=0.1,
-            trk_assoc_iou_thresh=0.5,
-            suppress_overlapping_based_on_recent_occlusion_threshold=1.0,
-        )
+        with timed(timings, "sam3_plant_detect"):
+            plant_result = call_sam3_api(
+                image,
+                endpoint="detect",
+                text_prompt="plant",
+                recondition_on_trk_masks=False,
+                recondition_every_nth_frame=1,
+                score_threshold_detection=0.165,
+                high_conf_thresh=0.3,
+                high_iou_thresh=0.5,
+                new_det_thresh=0.5,
+                det_nms_thresh=0.5,
+                assoc_iou_thresh=0.1,
+                trk_assoc_iou_thresh=0.5,
+                suppress_overlapping_based_on_recent_occlusion_threshold=1.0,
+            )
         plant_state_from_sam3 = plant_result["session_id"]
         plant_masks = plant_result.get("masks", [])
 
@@ -69,8 +78,13 @@ def detect():
             sorted_pot_masks,
             sam3_session_id=pot_state_from_sam3,
             cleaning_state=cleaning_state,
+            profile=timings,
         )
+        if timings is not None:
+            timings["total"] = time.perf_counter() - request_start
         response["state"]["plant_state"] = plant_state_from_sam3
+        if timings is not None:
+            response["profile"] = timings
 
         logger.info(
             f"detect: pot_masks={len(response['pot_masks'])}, ordered_pot_ids={len(response['ordered_pot_ids'])}"

--- a/api/pipeline/app/plant/stats.py
+++ b/api/pipeline/app/plant/stats.py
@@ -118,48 +118,36 @@ def _circular_hue_mean_and_std(hue: np.ndarray) -> tuple[float, float]:
 def _color_means_for_masked_region(
     warped_image_np: np.ndarray, mask: np.ndarray
 ) -> dict:
-    """Mean colour stats over the masked region, matching plantcv.analyze.color.
+    """Mean colour stats over the masked region (RGB input).
 
-    plantcv treats the input array as BGR: it splits the channels as ``b, g, r``
-    and converts with ``COLOR_BGR2LAB`` / ``COLOR_BGR2HSV``. The pipeline feeds
-    RGB images, so we replicate that exact (BGR-interpreting) derivation and key
-    mapping so these stats mean the same thing they always have — i.e. plantcv's
-    ``red_frequencies`` channel is array channel 2, ``blue_frequencies`` is array
-    channel 0, and LAB/HSV are computed on the BGR-interpreted array. Scales also
-    follow plantcv's observation labels: RGB→0-255, L/S/V→0-100 (percent_values),
-    a*/b*→-128..127 (diverging_values), hue→degrees.
+    Scales follow plantcv's observation labels: RGB→0-255, L/S/V→0-100,
+    a*/b*→-128..127, hue→degrees (bin midpoint i*2+1).
     """
     idx = mask > 0
     if not np.any(idx):
         means = {k: 0.0 for k in _COLOR_MEAN_KEYS}
-        # plantcv reports NaN hue circular stats when there are no hue>0 pixels.
         means["hue_circular_mean"] = float("nan")
         means["hue_circular_std"] = float("nan")
         return means
 
-    # Crop to the mask bounding box so the colour-space conversions and the
-    # per-channel reductions only touch the plant region, not the full frame.
+    # Crop to the mask bounding box so conversions only touch the plant region.
     ys, xs = np.nonzero(idx)
     y0, y1 = int(ys.min()), int(ys.max()) + 1
     x0, x1 = int(xs.min()), int(xs.max()) + 1
     img = warped_image_np[y0:y1, x0:x1]
     sel = idx[y0:y1, x0:x1]
 
-    # plantcv labels the split channels b, g, r assuming a BGR array; index first,
-    # then convert only the surviving masked pixels to float.
-    blue = img[..., 0][sel].astype(np.float32)
+    red = img[..., 0][sel].astype(np.float32)
     green = img[..., 1][sel].astype(np.float32)
-    red = img[..., 2][sel].astype(np.float32)
+    blue = img[..., 2][sel].astype(np.float32)
 
-    lab = cv2.cvtColor(img, cv2.COLOR_BGR2LAB)
+    lab = cv2.cvtColor(img, cv2.COLOR_RGB2LAB)
     lightness = lab[..., 0][sel].astype(np.float32) * 100.0 / 255.0
     green_magenta = lab[..., 1][sel].astype(np.float32) - 128.0
     blue_yellow = lab[..., 2][sel].astype(np.float32) - 128.0
 
-    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+    hsv = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)
     hue = hsv[..., 0][sel].astype(np.float32)
-    # plantcv labels saturation and value with percent_values (0-100), exactly
-    # as it does lightness, so rescale both from the encoded 0-255 range.
     saturation = hsv[..., 1][sel].astype(np.float32) * 100.0 / 255.0
     value = hsv[..., 2][sel].astype(np.float32) * 100.0 / 255.0
 
@@ -171,8 +159,6 @@ def _color_means_for_masked_region(
         "blue_frequencies_mean": float(blue.mean()),
         "green-magenta_frequencies_mean": float(green_magenta.mean()),
         "blue-yellow_frequencies_mean": float(blue_yellow.mean()),
-        # plantcv labels hue bin i with the interval midpoint i*2+1 (degrees),
-        # so the label-weighted mean is 2*mean(hue) + 1.
         "hue_frequencies_mean": float((hue * 2.0 + 1.0).mean()),
         "hue_circular_mean": hue_circular_mean,
         "hue_circular_std": hue_circular_std,

--- a/api/pipeline/app/plant/stats.py
+++ b/api/pipeline/app/plant/stats.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import cv2
 import numpy as np
 from plantcv import plantcv as pcv
+from scipy import stats as scipy_stats
 
 logger = logging.getLogger(__name__)
 
@@ -99,63 +100,79 @@ _COLOR_MEAN_KEYS = (
 )
 
 
-def _circular_mean_and_std(degrees: np.ndarray) -> tuple[float, float]:
-    """Circular mean/std (in degrees) of a 1-D array of angles in degrees."""
-    count = degrees.size
-    if count == 0:
-        return 0.0, 0.0
-    radians = np.deg2rad(degrees)
-    sin_sum = float(np.sum(np.sin(radians)))
-    cos_sum = float(np.sum(np.cos(radians)))
-    mean_angle = np.arctan2(sin_sum, cos_sum)
-    if mean_angle < 0:
-        mean_angle += 2 * np.pi
-    R = np.hypot(sin_sum, cos_sum) / count
-    circ_std = np.sqrt(max(0.0, -2.0 * np.log(max(R, 1e-12))))
-    return float(np.rad2deg(mean_angle)), float(np.rad2deg(circ_std))
+def _circular_hue_mean_and_std(hue: np.ndarray) -> tuple[float, float]:
+    """Circular mean/std of OpenCV-encoded hue (0-179), reported in degrees (0-359).
+
+    Mirrors plantcv.analyze.color: hue==0 marks red/undefined-hue (saturated)
+    pixels and is excluded, and an all-zero/empty selection yields NaN (not 0.0),
+    matching scipy.stats.circmean/circstd on an empty array.
+    """
+    nonzero = hue[hue > 0]
+    if nonzero.size == 0:
+        return float("nan"), float("nan")
+    mean = float(scipy_stats.circmean(nonzero, high=179, low=0) * 2)
+    std = float(scipy_stats.circstd(nonzero, high=179, low=0) * 2)
+    return mean, std
 
 
 def _color_means_for_masked_region(
     warped_image_np: np.ndarray, mask: np.ndarray
 ) -> dict:
-    """Mean colour stats over the masked pixels, in plantcv's key/scale conventions."""
+    """Mean colour stats over the masked region, matching plantcv.analyze.color.
+
+    plantcv treats the input array as BGR: it splits the channels as ``b, g, r``
+    and converts with ``COLOR_BGR2LAB`` / ``COLOR_BGR2HSV``. The pipeline feeds
+    RGB images, so we replicate that exact (BGR-interpreting) derivation and key
+    mapping so these stats mean the same thing they always have — i.e. plantcv's
+    ``red_frequencies`` channel is array channel 2, ``blue_frequencies`` is array
+    channel 0, and LAB/HSV are computed on the BGR-interpreted array. Scales also
+    follow plantcv: L→0-100, a*/b*→-128..127, hue→degrees, RGB/S/V→0-255.
+    """
     idx = mask > 0
     if not np.any(idx):
-        return {k: 0.0 for k in _COLOR_MEAN_KEYS}
+        means = {k: 0.0 for k in _COLOR_MEAN_KEYS}
+        # plantcv reports NaN hue circular stats when there are no hue>0 pixels.
+        means["hue_circular_mean"] = float("nan")
+        means["hue_circular_std"] = float("nan")
+        return means
 
     # Crop to the mask bounding box so the colour-space conversions and the
     # per-channel reductions only touch the plant region, not the full frame.
     ys, xs = np.nonzero(idx)
     y0, y1 = int(ys.min()), int(ys.max()) + 1
     x0, x1 = int(xs.min()), int(xs.max()) + 1
-    rgb = warped_image_np[y0:y1, x0:x1]
+    img = warped_image_np[y0:y1, x0:x1]
     sel = idx[y0:y1, x0:x1]
 
-    hsv = cv2.cvtColor(rgb, cv2.COLOR_RGB2HSV)
-    lab = cv2.cvtColor(rgb, cv2.COLOR_RGB2LAB)
+    # plantcv labels the split channels b, g, r assuming a BGR array; index first,
+    # then convert only the surviving masked pixels to float.
+    blue = img[..., 0][sel].astype(np.float32)
+    green = img[..., 1][sel].astype(np.float32)
+    red = img[..., 2][sel].astype(np.float32)
 
-    # Reduce each channel to just the masked pixels before averaging.
-    r = rgb[..., 0].astype(np.float32)[sel]
-    g = rgb[..., 1].astype(np.float32)[sel]
-    b = rgb[..., 2].astype(np.float32)[sel]
-    h = hsv[..., 0].astype(np.float32)[sel] * 2.0
-    s = hsv[..., 1].astype(np.float32)[sel]
-    v = hsv[..., 2].astype(np.float32)[sel]
-    lightness = lab[..., 0].astype(np.float32)[sel] * 100.0 / 255.0
+    lab = cv2.cvtColor(img, cv2.COLOR_BGR2LAB)
+    lightness = lab[..., 0][sel].astype(np.float32) * 100.0 / 255.0
+    green_magenta = lab[..., 1][sel].astype(np.float32) - 128.0
+    blue_yellow = lab[..., 2][sel].astype(np.float32) - 128.0
 
-    hue_circular_mean, hue_circular_std = _circular_mean_and_std(h)
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+    hue = hsv[..., 0][sel].astype(np.float32)
+    saturation = hsv[..., 1][sel].astype(np.float32)
+    value = hsv[..., 2][sel].astype(np.float32)
+
+    hue_circular_mean, hue_circular_std = _circular_hue_mean_and_std(hue)
 
     return {
-        "red_frequencies_mean": float(r.mean()),
-        "green_frequencies_mean": float(g.mean()),
-        "blue_frequencies_mean": float(b.mean()),
-        "green-magenta_frequencies_mean": float((g - r).mean()),
-        "blue-yellow_frequencies_mean": float((b - (r + g) / 2.0).mean()),
-        "hue_frequencies_mean": float(h.mean()),
+        "red_frequencies_mean": float(red.mean()),
+        "green_frequencies_mean": float(green.mean()),
+        "blue_frequencies_mean": float(blue.mean()),
+        "green-magenta_frequencies_mean": float(green_magenta.mean()),
+        "blue-yellow_frequencies_mean": float(blue_yellow.mean()),
+        "hue_frequencies_mean": float((hue * 2.0).mean()),
         "hue_circular_mean": hue_circular_mean,
         "hue_circular_std": hue_circular_std,
-        "saturation_frequencies_mean": float(s.mean()),
-        "value_frequencies_mean": float(v.mean()),
+        "saturation_frequencies_mean": float(saturation.mean()),
+        "value_frequencies_mean": float(value.mean()),
         "lightness_frequencies_mean": float(lightness.mean()),
     }
 

--- a/api/pipeline/app/plant/stats.py
+++ b/api/pipeline/app/plant/stats.py
@@ -126,7 +126,8 @@ def _color_means_for_masked_region(
     mapping so these stats mean the same thing they always have — i.e. plantcv's
     ``red_frequencies`` channel is array channel 2, ``blue_frequencies`` is array
     channel 0, and LAB/HSV are computed on the BGR-interpreted array. Scales also
-    follow plantcv: L→0-100, a*/b*→-128..127, hue→degrees, RGB/S/V→0-255.
+    follow plantcv's observation labels: RGB→0-255, L/S/V→0-100 (percent_values),
+    a*/b*→-128..127 (diverging_values), hue→degrees.
     """
     idx = mask > 0
     if not np.any(idx):
@@ -157,8 +158,10 @@ def _color_means_for_masked_region(
 
     hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
     hue = hsv[..., 0][sel].astype(np.float32)
-    saturation = hsv[..., 1][sel].astype(np.float32)
-    value = hsv[..., 2][sel].astype(np.float32)
+    # plantcv labels saturation and value with percent_values (0-100), exactly
+    # as it does lightness, so rescale both from the encoded 0-255 range.
+    saturation = hsv[..., 1][sel].astype(np.float32) * 100.0 / 255.0
+    value = hsv[..., 2][sel].astype(np.float32) * 100.0 / 255.0
 
     hue_circular_mean, hue_circular_std = _circular_hue_mean_and_std(hue)
 
@@ -168,7 +171,9 @@ def _color_means_for_masked_region(
         "blue_frequencies_mean": float(blue.mean()),
         "green-magenta_frequencies_mean": float(green_magenta.mean()),
         "blue-yellow_frequencies_mean": float(blue_yellow.mean()),
-        "hue_frequencies_mean": float((hue * 2.0).mean()),
+        # plantcv labels hue bin i with the interval midpoint i*2+1 (degrees),
+        # so the label-weighted mean is 2*mean(hue) + 1.
+        "hue_frequencies_mean": float((hue * 2.0 + 1.0).mean()),
         "hue_circular_mean": hue_circular_mean,
         "hue_circular_std": hue_circular_std,
         "saturation_frequencies_mean": float(saturation.mean()),

--- a/api/pipeline/app/plant/stats.py
+++ b/api/pipeline/app/plant/stats.py
@@ -1,8 +1,33 @@
+import logging
+import time
+from contextlib import contextmanager
+
+import cv2
 import numpy as np
 from plantcv import plantcv as pcv
-import logging
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _timed_accumulate(profile: dict | None, key: str):
+    """Accumulate elapsed seconds into profile['analyze_plant_mask_detail'][key]."""
+    if profile is None:
+        yield
+        return
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        timings = profile.setdefault("analyze_plant_mask_detail", {})
+        timings[key] = timings.get(key, 0.0) + (time.perf_counter() - start)
+
+
+def _increment_profile_count(profile: dict | None) -> None:
+    if profile is None:
+        return
+    timings = profile.setdefault("analyze_plant_mask_detail", {})
+    timings["count"] = timings.get("count", 0) + 1
 
 
 def calculate_scale_factor(
@@ -59,11 +84,88 @@ def calculate_histogram_mean(histogram: list) -> float:
     return float(np.mean(repeated_values))
 
 
+_COLOR_MEAN_KEYS = (
+    "red_frequencies_mean",
+    "green_frequencies_mean",
+    "blue_frequencies_mean",
+    "green-magenta_frequencies_mean",
+    "blue-yellow_frequencies_mean",
+    "hue_frequencies_mean",
+    "hue_circular_mean",
+    "hue_circular_std",
+    "saturation_frequencies_mean",
+    "value_frequencies_mean",
+    "lightness_frequencies_mean",
+)
+
+
+def _circular_mean_and_std(degrees: np.ndarray) -> tuple[float, float]:
+    """Circular mean/std (in degrees) of a 1-D array of angles in degrees."""
+    count = degrees.size
+    if count == 0:
+        return 0.0, 0.0
+    radians = np.deg2rad(degrees)
+    sin_sum = float(np.sum(np.sin(radians)))
+    cos_sum = float(np.sum(np.cos(radians)))
+    mean_angle = np.arctan2(sin_sum, cos_sum)
+    if mean_angle < 0:
+        mean_angle += 2 * np.pi
+    R = np.hypot(sin_sum, cos_sum) / count
+    circ_std = np.sqrt(max(0.0, -2.0 * np.log(max(R, 1e-12))))
+    return float(np.rad2deg(mean_angle)), float(np.rad2deg(circ_std))
+
+
+def _color_means_for_masked_region(
+    warped_image_np: np.ndarray, mask: np.ndarray
+) -> dict:
+    """Mean colour stats over the masked pixels, in plantcv's key/scale conventions."""
+    idx = mask > 0
+    if not np.any(idx):
+        return {k: 0.0 for k in _COLOR_MEAN_KEYS}
+
+    # Crop to the mask bounding box so the colour-space conversions and the
+    # per-channel reductions only touch the plant region, not the full frame.
+    ys, xs = np.nonzero(idx)
+    y0, y1 = int(ys.min()), int(ys.max()) + 1
+    x0, x1 = int(xs.min()), int(xs.max()) + 1
+    rgb = warped_image_np[y0:y1, x0:x1]
+    sel = idx[y0:y1, x0:x1]
+
+    hsv = cv2.cvtColor(rgb, cv2.COLOR_RGB2HSV)
+    lab = cv2.cvtColor(rgb, cv2.COLOR_RGB2LAB)
+
+    # Reduce each channel to just the masked pixels before averaging.
+    r = rgb[..., 0].astype(np.float32)[sel]
+    g = rgb[..., 1].astype(np.float32)[sel]
+    b = rgb[..., 2].astype(np.float32)[sel]
+    h = hsv[..., 0].astype(np.float32)[sel] * 2.0
+    s = hsv[..., 1].astype(np.float32)[sel]
+    v = hsv[..., 2].astype(np.float32)[sel]
+    lightness = lab[..., 0].astype(np.float32)[sel] * 100.0 / 255.0
+
+    hue_circular_mean, hue_circular_std = _circular_mean_and_std(h)
+
+    return {
+        "red_frequencies_mean": float(r.mean()),
+        "green_frequencies_mean": float(g.mean()),
+        "blue_frequencies_mean": float(b.mean()),
+        "green-magenta_frequencies_mean": float((g - r).mean()),
+        "blue-yellow_frequencies_mean": float((b - (r + g) / 2.0).mean()),
+        "hue_frequencies_mean": float(h.mean()),
+        "hue_circular_mean": hue_circular_mean,
+        "hue_circular_std": hue_circular_std,
+        "saturation_frequencies_mean": float(s.mean()),
+        "value_frequencies_mean": float(v.mean()),
+        "lightness_frequencies_mean": float(lightness.mean()),
+    }
+
+
 def analyze_plant_mask(
     warped_image_np: np.ndarray,
     mask_binary: np.ndarray,
     pot_size_mm: float = 60.0,
     margin: float = 0.25,
+    profile: dict | None = None,
 ):
     """
     Analyze a plant mask using PlantCV to extract morphological features.
@@ -79,87 +181,85 @@ def analyze_plant_mask(
         visualization: Numpy array of visualization image (or None)
     """
 
-    # Calculate scale factor: pixels per mm
-    image_height, image_width = warped_image_np.shape[:2]
-    scale = calculate_scale_factor(image_width, pot_size_mm, margin)
+    with _timed_accumulate(profile, "total"):
+        _increment_profile_count(profile)
 
-    labeled_mask = np.where(mask_binary > 0, 1, 0).astype(np.uint8)
-    n_pixels = np.sum(labeled_mask)
-    print(
-        f"DEBUG: Analyze plant mask: scale={scale:.4f}, plant_pixels={n_pixels}",
-        flush=True,
-    )
-    logger.debug(f"Analyze plant mask: scale={scale:.4f}, plant_pixels={n_pixels}")
+        # Calculate scale factor: pixels per mm
+        image_height, image_width = warped_image_np.shape[:2]
+        scale = calculate_scale_factor(image_width, pot_size_mm, margin)
 
-    # Set PlantCV parameters
-    pcv.params.line_thickness = 2
-    pcv.params.debug = None
-
-    # Clear previous observations
-    pcv.outputs.clear()
-
-    try:
-        # Size analysis
-        analysis_image = pcv.analyze.size(
-            img=warped_image_np, labeled_mask=labeled_mask, n_labels=1
+        labeled_mask = np.where(mask_binary > 0, 1, 0).astype(np.uint8)
+        n_pixels = np.sum(labeled_mask)
+        print(
+            f"DEBUG: Analyze plant mask: scale={scale:.4f}, plant_pixels={n_pixels}",
+            flush=True,
         )
+        logger.debug(f"Analyze plant mask: scale={scale:.4f}, plant_pixels={n_pixels}")
 
-        # Color analysis
-        pcv.analyze.color(
-            rgb_img=warped_image_np,
-            labeled_mask=labeled_mask,
-            n_labels=1,
-            colorspaces="all",
-        )
+        # Set PlantCV parameters
+        pcv.params.line_thickness = 2
+        pcv.params.debug = None
 
-    except Exception as e:
-        # Return empty stats if analysis fails
-        logger.error(f"PlantCV analysis failed: {e}")
-        return {
-            "area": None,
-            "convex_hull_area": None,
-            "solidity": None,
-            "perimeter": None,
-            "width": None,
-            "height": None,
-            "longest_path": None,
-            "center_of_mass_x": None,
-            "center_of_mass_y": None,
-            "convex_hull_vertices": 0,
-            "object_in_frame": 0,
-            "ellipse_center_x": None,
-            "ellipse_center_y": None,
-            "ellipse_major_axis": None,
-            "ellipse_minor_axis": None,
-            "ellipse_angle": None,
-            "ellipse_eccentricity": None,
-            "blue-yellow_frequencies_mean": None,
-            "blue_frequencies_mean": None,
-            "green-magenta_frequencies_mean": None,
-            "green_frequencies_mean": None,
-            "hue_circular_mean": None,
-            "hue_circular_std": None,
-            "hue_frequencies_mean": None,
-            "lightness_frequencies_mean": None,
-            "red_frequencies_mean": None,
-            "saturation_frequencies_mean": None,
-            "value_frequencies_mean": None,
-            "error": str(e),
-        }, None
+        # Clear previous observations
+        pcv.outputs.clear()
 
-    stats = {}
+        try:
+            # Size analysis
+            with _timed_accumulate(profile, "size_analysis"):
+                analysis_image = pcv.analyze.size(
+                    img=warped_image_np, labeled_mask=labeled_mask, n_labels=1
+                )
 
-    # pcv.outputs.observations is a dict of observations
-    # For analyze.size and analyze.color, they usually share the same sample name if n_labels=1
-    for observation_label, observation in pcv.outputs.observations.items():
-        for variable, value in observation.items():
-            if variable in ["center_of_mass", "ellipse_center"]:
-                stats[variable + "_x"], stats[variable + "_y"] = value["value"]
-            elif "frequencies" in variable:
-                stats[f"{variable}_mean"] = calculate_histogram_mean(value["value"])
-            else:
-                stats[variable] = value["value"]
+            # Fast custom color means analysis
+            with _timed_accumulate(profile, "color_analysis"):
+                color_stats = _color_means_for_masked_region(
+                    warped_image_np, labeled_mask > 0
+                )
 
-    stats = convert_px_to_mm(stats, scale)
+        except Exception as e:
+            # Return empty stats if analysis fails
+            logger.error(f"PlantCV analysis failed: {e}")
+            return {
+                "area": None,
+                "convex_hull_area": None,
+                "solidity": None,
+                "perimeter": None,
+                "width": None,
+                "height": None,
+                "longest_path": None,
+                "center_of_mass_x": None,
+                "center_of_mass_y": None,
+                "convex_hull_vertices": 0,
+                "object_in_frame": 0,
+                "ellipse_center_x": None,
+                "ellipse_center_y": None,
+                "ellipse_major_axis": None,
+                "ellipse_minor_axis": None,
+                "ellipse_angle": None,
+                "ellipse_eccentricity": None,
+                **{k: None for k in _COLOR_MEAN_KEYS},
+                "error": str(e),
+            }, None
+
+        stats = {}
+
+        # pcv.outputs.observations is a dict of observations from analyze.size
+        # (color stats are computed separately via _color_means_for_masked_region).
+        with _timed_accumulate(profile, "observations"):
+            for observation_label, observation in pcv.outputs.observations.items():
+                for variable, value in observation.items():
+                    if variable in ["center_of_mass", "ellipse_center"]:
+                        stats[variable + "_x"], stats[variable + "_y"] = value["value"]
+                    elif "frequencies" in variable:
+                        stats[f"{variable}_mean"] = calculate_histogram_mean(
+                            value["value"]
+                        )
+                    else:
+                        stats[variable] = value["value"]
+
+        stats.update(color_stats)
+
+        with _timed_accumulate(profile, "convert_px_to_mm"):
+            stats = convert_px_to_mm(stats, scale)
 
     return stats, analysis_image

--- a/api/pipeline/app/propagate.py
+++ b/api/pipeline/app/propagate.py
@@ -1,17 +1,19 @@
 import logging
+import time
 
 import numpy as np
 from flask import Blueprint, jsonify, request
 
+from app.cv_utils import safe_fill_poly
 from app.pot.detect import filter_pot_masks
 from app.utils import (
     associate_plants_to_pots,
     call_sam3_api,
     decode_image,
     process_pipeline_outputs,
+    timed,
     unwrap_state,
 )
-from app.cv_utils import safe_fill_poly
 
 logger = logging.getLogger(__name__)
 
@@ -40,19 +42,24 @@ def propagate():
     """
     try:
         data = request.json
+        profile_enabled = bool(data.get("profile"))
+        timings = {} if profile_enabled else None
+        request_start = time.perf_counter()
         state_in = data.get("state", {})
 
         image_data = data["image_data"]
         pot_state = state_in.get("pot_state")
         plant_state = state_in.get("plant_state")
         cleaning_state = state_in.get("cleaning_state")
-        image = decode_image(image_data)
+        with timed(timings, "decode_image"):
+            image = decode_image(image_data)
         image_np = np.array(image)
         h, w = image_np.shape[:2]
 
         response = {}
         plant_masks = []
-        pot_session_id, id_map, p_masks_raw_old = unwrap_state(pot_state)
+        with timed(timings, "unwrap_state"):
+            pot_session_id, id_map, p_masks_raw_old = unwrap_state(pot_state)
 
         if pot_state:
             # Get options from request
@@ -71,13 +78,15 @@ def propagate():
                 ]:
                     pot_params[k] = v
 
-            pot_result = call_sam3_api(
-                image,
-                endpoint="propagate",
-                state=pot_session_id,
-                **pot_params,
-            )
-            p_masks_raw_new = filter_pot_masks(pot_result.get("masks", []), image_np)
+            with timed(timings, "sam3_pot_propagate"):
+                pot_result = call_sam3_api(
+                    image,
+                    endpoint="propagate",
+                    state=pot_session_id,
+                    **pot_params,
+                )
+            with timed(timings, "filter_pot_masks"):
+                p_masks_raw_new = filter_pot_masks(pot_result.get("masks", []), image_np)
 
             # Mapping new masks back to stable IDs and handling outgrowth
             old_mask_lookup = (
@@ -89,20 +98,21 @@ def propagate():
             plant_session_id = None
             if plant_state:
                 # For the plant SAM3 request, we want to run mask reconditioning every frame
-                plant_result = call_sam3_api(
-                    image,
-                    endpoint="propagate",
-                    state=plant_state,
-                    recondition_on_trk_masks=True,
-                    recondition_every_nth_frame=1,
-                    score_threshold_detection=0.165,
-                    high_conf_thresh=0.165,
-                    high_iou_thresh=0.0001,
-                    new_det_thresh=0.2,
-                    det_nms_thresh=0.01,
-                    assoc_iou_thresh=0.0001,
-                    trk_assoc_iou_thresh=0.0001,
-                )
+                with timed(timings, "sam3_plant_propagate"):
+                    plant_result = call_sam3_api(
+                        image,
+                        endpoint="propagate",
+                        state=plant_state,
+                        recondition_on_trk_masks=True,
+                        recondition_every_nth_frame=1,
+                        score_threshold_detection=0.165,
+                        high_conf_thresh=0.165,
+                        high_iou_thresh=0.0001,
+                        new_det_thresh=0.2,
+                        det_nms_thresh=0.01,
+                        assoc_iou_thresh=0.0001,
+                        trk_assoc_iou_thresh=0.0001,
+                    )
                 plant_masks = plant_result.get("masks", [])
                 plant_session_id = plant_result.get("session_id")
 
@@ -110,6 +120,7 @@ def propagate():
             # We need to temporarily associate current plants with previous pots to check containment
             # Note: process_pipeline_outputs will do the FINAL association for the response
             # p_masks_raw_old has stable IDs, plant_masks has SAM3 IDs
+            outgrowth_start = time.perf_counter()
             newly_outgrown_stable_ids = set()
             if enable_outgrowth_lock:
                 temp_associations = associate_plants_to_pots(
@@ -145,6 +156,8 @@ def propagate():
                             logger.info(
                                 f"Pot {stable_pot_id} detection: Plant at t outgrew Pot at t-1. Outside pixels: {outside_pixels}"
                             )
+            if timings is not None:
+                timings["outgrowth_check"] = time.perf_counter() - outgrowth_start
 
             new_mask_by_stable_id = {}
             for m_new in p_masks_raw_new:
@@ -187,10 +200,14 @@ def propagate():
                 id_map=id_map,
                 sam3_session_id=pot_session_id,
                 cleaning_state=cleaning_state,
+                profile=timings,
             )
             response["state"]["plant_state"] = plant_session_id
             response["debug_plant_mask_sam3_count"] = len(plant_masks)
             response["debug_pot_masks_count"] = len(final_p_masks_raw)
+            if timings is not None:
+                timings["total"] = time.perf_counter() - request_start
+                response["profile"] = timings
 
         return jsonify(response)
     except Exception as e:

--- a/api/pipeline/app/propagate.py
+++ b/api/pipeline/app/propagate.py
@@ -86,7 +86,9 @@ def propagate():
                     **pot_params,
                 )
             with timed(timings, "filter_pot_masks"):
-                p_masks_raw_new = filter_pot_masks(pot_result.get("masks", []), image_np)
+                p_masks_raw_new = filter_pot_masks(
+                    pot_result.get("masks", []), image_np
+                )
 
             # Mapping new masks back to stable IDs and handling outgrowth
             old_mask_lookup = (

--- a/api/pipeline/app/utils.py
+++ b/api/pipeline/app/utils.py
@@ -3,6 +3,8 @@ import base64
 import io
 import json
 import logging
+import time
+from contextlib import contextmanager
 
 import cv2
 import httpx
@@ -11,18 +13,30 @@ import requests
 from PIL import Image
 from requests.adapters import HTTPAdapter, Retry
 
-from app.plant.stats import analyze_plant_mask
-from app.pot.quad import mask_to_quadrilateral
-from app.pot.visualize import visualize_pipeline_tracking
-from app.pot.warp import warp_quad_to_square
 from app.analysis import (
     apply_tukey_outlier_detection_frame,
     update_plant_cleaning_state,
 )
-
 from app.cv_utils import safe_fill_poly
+from app.plant.stats import analyze_plant_mask
+from app.pot.quad import mask_to_quadrilateral
+from app.pot.visualize import visualize_pipeline_tracking
+from app.pot.warp import warp_quad_to_square
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def timed(timings: dict | None, key: str):
+    """Record elapsed seconds into timings[key]; a no-op when timings is None."""
+    if timings is None:
+        yield
+        return
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        timings[key] = time.perf_counter() - start
 
 
 def encode_image(image: Image.Image | np.ndarray) -> str:
@@ -426,10 +440,15 @@ def apply_id_mapping(masks, id_map):
     return remapped_masks, id_map
 
 
-def process_pot_stats(image_np, pot_masks, plant_masks, associations):
+def process_pot_stats(image_np, pot_masks, plant_masks, associations, profile=None):
     """
     Compute statistics for each plant in its respective pot.
     """
+    timings = None
+    if profile is not None:
+        timings = profile.setdefault("process_pot_stats", {})
+        timings_start = time.perf_counter()
+
     h, w = image_np.shape[:2]
     stats_dict = {}
 
@@ -459,84 +478,94 @@ def process_pot_stats(image_np, pot_masks, plant_masks, associations):
 
     # 1. Generate warped images (synchronously for now as CV2 is fast)
     warped_images_info = []
-    for task in processing_tasks:
-        try:
-            pot_id = task["pot_id"]
-            pot = task["pot"]
-            plant_info = task["plant_info"]
+    with timed(timings, "warp_and_encode"):
+        for task in processing_tasks:
+            try:
+                pot_id = task["pot_id"]
+                pot = task["pot"]
+                plant_info = task["plant_info"]
 
-            # Pot Quad
-            pot_mask_single = np.zeros((h, w), dtype=np.uint8)
-            if "contour" in pot:
-                safe_fill_poly(pot_mask_single, pot["contour"], 1)
-            quad = mask_to_quadrilateral(pot_mask_single)
+                # Pot Quad
+                pot_mask_single = np.zeros((h, w), dtype=np.uint8)
+                if "contour" in pot:
+                    safe_fill_poly(pot_mask_single, pot["contour"], 1)
+                quad = mask_to_quadrilateral(pot_mask_single)
 
-            # Warp Pot Image
-            output_size = 224
-            warped_pot, H = warp_quad_to_square(image_np, quad, output_size=output_size)
+                # Warp Pot Image
+                output_size = 224
+                warped_pot, H = warp_quad_to_square(
+                    image_np, quad, output_size=output_size
+                )
 
-            # Warp Plant Mask
-            p_contours = plant_info.get("contours")
-            plant_mask_single = np.zeros((h, w), dtype=np.uint8)
-            if p_contours:
-                safe_fill_poly(plant_mask_single, p_contours, 255)
-            else:
-                plant_contour = plant_info.get("contour")
-                if plant_contour:
-                    safe_fill_poly(plant_mask_single, plant_contour, 255)
+                # Warp Plant Mask
+                p_contours = plant_info.get("contours")
+                plant_mask_single = np.zeros((h, w), dtype=np.uint8)
+                if p_contours:
+                    safe_fill_poly(plant_mask_single, p_contours, 255)
+                else:
+                    plant_contour = plant_info.get("contour")
+                    if plant_contour:
+                        safe_fill_poly(plant_mask_single, plant_contour, 255)
 
-            warped_plant_mask = cv2.warpPerspective(
-                plant_mask_single,
-                H,
-                (output_size, output_size),
-                flags=cv2.INTER_NEAREST,
-            )
+                warped_plant_mask = cv2.warpPerspective(
+                    plant_mask_single,
+                    H,
+                    (output_size, output_size),
+                    flags=cv2.INTER_NEAREST,
+                )
 
-            # Encode to B64
-            pill_warped = Image.fromarray(warped_pot)
-            buffered = io.BytesIO()
-            pill_warped.save(buffered, format="JPEG")
-            warped_b64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
+                # Encode to B64
+                pill_warped = Image.fromarray(warped_pot)
+                buffered = io.BytesIO()
+                pill_warped.save(buffered, format="JPEG")
+                warped_b64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
 
-            warped_images_info.append(
-                {
-                    "pot_id": pot_id,
-                    "warped_pot": warped_pot,
-                    "warped_plant_mask": warped_plant_mask,
-                    "warped_b64": warped_b64,
-                    "plant_id": plant_info["object_id"],
-                }
-            )
-        except Exception as e:
-            logger.error(f"Error preparing warp for pot {task['pot_id']}: {e}")
-            stats_dict[str(task["pot_id"])] = {"error": str(e)}
+                warped_images_info.append(
+                    {
+                        "pot_id": pot_id,
+                        "warped_pot": warped_pot,
+                        "warped_plant_mask": warped_plant_mask,
+                        "warped_b64": warped_b64,
+                        "plant_id": plant_info["object_id"],
+                    }
+                )
+            except Exception as e:
+                logger.error(f"Error preparing warp for pot {task['pot_id']}: {e}")
+                stats_dict[str(task["pot_id"])] = {"error": str(e)}
 
     # 2. Get embeddings asynchronously
     if warped_images_info:
         warped_b64_list = [info["warped_b64"] for info in warped_images_info]
-        embeddings_results = asyncio.run(async_get_embeddings(warped_b64_list))
+        with timed(timings, "embeddings"):
+            embeddings_results = asyncio.run(async_get_embeddings(warped_b64_list))
 
-        for info, emb_res in zip(warped_images_info, embeddings_results):
-            pot_id = info["pot_id"]
-            try:
-                # 3. Analyze Plant Stats
-                plant_stats, _ = analyze_plant_mask(
-                    info["warped_pot"], info["warped_plant_mask"]
-                )
-                plant_stats["warped_image"] = info["warped_b64"]
+        with timed(timings, "analyze_plant_mask"):
+            for info, emb_res in zip(warped_images_info, embeddings_results):
+                pot_id = info["pot_id"]
+                try:
+                    # 3. Analyze Plant Stats
+                    plant_stats, _ = analyze_plant_mask(
+                        info["warped_pot"],
+                        info["warped_plant_mask"],
+                        profile=profile,
+                    )
+                    plant_stats["warped_image"] = info["warped_b64"]
 
-                # 4. Integrate Embeddings
-                if "cls_token" in emb_res:
-                    plant_stats["cls_token"] = emb_res["cls_token"]
-                elif "error" in emb_res:
-                    plant_stats["cls_token_error"] = emb_res["error"]
+                    # 4. Integrate Embeddings
+                    if "cls_token" in emb_res:
+                        plant_stats["cls_token"] = emb_res["cls_token"]
+                    elif "error" in emb_res:
+                        plant_stats["cls_token_error"] = emb_res["error"]
 
-                plant_stats["plant_id"] = info["plant_id"]
-                plant_stats["pot_id"] = pot_id
-                stats_dict[str(pot_id)] = plant_stats
-            except Exception as e:
-                logger.error(f"Error finalising stats for pot {pot_id}: {e}")
-                stats_dict[str(pot_id)] = {"error": str(e)}
+                    plant_stats["plant_id"] = info["plant_id"]
+                    plant_stats["pot_id"] = pot_id
+                    stats_dict[str(pot_id)] = plant_stats
+                except Exception as e:
+                    logger.error(f"Error finalising stats for pot {pot_id}: {e}")
+                    stats_dict[str(pot_id)] = {"error": str(e)}
+
+    if timings is not None:
+        timings["total"] = time.perf_counter() - timings_start
 
     return stats_dict
 
@@ -548,27 +577,34 @@ def process_pipeline_outputs(
     id_map=None,
     sam3_session_id=None,
     cleaning_state=None,
+    profile=None,
 ):
     """
     Common post-processing for both detect and propagate endpoints.
     """
+    timings = None
+    if profile is not None:
+        timings = profile.setdefault("process_pipeline_outputs", {})
+        timings_start = time.perf_counter()
+
     response = {}
 
     # 1. ID Mapping
     state = {}
-    if id_map is not None:
-        pot_masks, updated_id_map = apply_id_mapping(pot_masks_raw, id_map)
-    else:
-        # Initial detection case: create ID map based on row-major order
-        sorted_pot_masks = order_masks_row_major(pot_masks_raw)
-        updated_id_map = {}
-        pot_masks = []
-        for new_id, m in enumerate(sorted_pot_masks):
-            old_id = str(m["object_id"])
-            updated_id_map[old_id] = new_id
-            m_new = m.copy()
-            m_new["object_id"] = new_id
-            pot_masks.append(m_new)
+    with timed(timings, "id_mapping"):
+        if id_map is not None:
+            pot_masks, updated_id_map = apply_id_mapping(pot_masks_raw, id_map)
+        else:
+            # Initial detection case: create ID map based on row-major order
+            sorted_pot_masks = order_masks_row_major(pot_masks_raw)
+            updated_id_map = {}
+            pot_masks = []
+            for new_id, m in enumerate(sorted_pot_masks):
+                old_id = str(m["object_id"])
+                updated_id_map[old_id] = new_id
+                m_new = m.copy()
+                m_new["object_id"] = new_id
+                pot_masks.append(m_new)
 
     if sam3_session_id is not None:
         state["pot_state"] = wrap_state(
@@ -576,19 +612,24 @@ def process_pipeline_outputs(
         )
 
     # 2. Refine plant masks
-    plant_masks, associations = refine_plant_masks(image_np, plant_masks, pot_masks)
+    with timed(timings, "refine_plant_masks"):
+        plant_masks, associations = refine_plant_masks(image_np, plant_masks, pot_masks)
 
     # 3. Refine pot masks and check for outgrowth
-    refine_pot_masks_with_plants(pot_masks, plant_masks, associations, image_np.shape)
+    with timed(timings, "refine_pot_masks"):
+        refine_pot_masks_with_plants(
+            pot_masks, plant_masks, associations, image_np.shape
+        )
 
     # 2.5 Filter plant masks to only include associated ones (ensures 1-to-1 matching in response)
     plant_masks = [p for p in plant_masks if str(p["object_id"]) in associations]
 
     # 4. Final ordering and results
     ordered_pot_masks = order_masks_row_major(pot_masks)
-    plant_stats = process_pot_stats(
-        image_np, ordered_pot_masks, plant_masks, associations
-    )
+    with timed(timings, "process_pot_stats_total"):
+        plant_stats = process_pot_stats(
+            image_np, ordered_pot_masks, plant_masks, associations, profile=profile
+        )
 
     # 5. Apply Stat Cleaning
     # Collect valid stats for Tukey
@@ -597,6 +638,7 @@ def process_pipeline_outputs(
         if s and "error" not in s:
             valid_stats_list.append(s)
 
+    clean_start = time.perf_counter()
     apply_tukey_outlier_detection_frame(valid_stats_list)
 
     if cleaning_state is None:
@@ -666,6 +708,10 @@ def process_pipeline_outputs(
                     plant_masks.append(prev_mask)
                     if sam3_plant_id is not None:
                         associations[sam3_plant_id] = last_pot_id
+
+    if timings is not None:
+        timings["cleaning"] = time.perf_counter() - clean_start
+        timings["total"] = time.perf_counter() - timings_start
 
     final_cleaning_state = cleaning_state.copy()
     final_cleaning_state.update(new_cleaning_state)

--- a/api/pipeline/tests/test_benchmark_parallel.py
+++ b/api/pipeline/tests/test_benchmark_parallel.py
@@ -1,0 +1,172 @@
+import base64
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+import requests
+
+# Path to test tracking frames (relative to this file)
+TRACKING_FRAMES_DIR = Path(__file__).parent / "test_data" / "tracking_frames"
+
+
+def get_service_url():
+    """Try localhost then pipeline hostname."""
+    for host in ["localhost", "pipeline"]:
+        url = f"http://{host}:8800/pipeline"
+        try:
+            requests.get(f"http://{host}:8800/health", timeout=1)
+            return url
+        except Exception:
+            continue
+    return "http://localhost:8800/pipeline"
+
+
+PIPELINE_BASE_URL = get_service_url()
+DETECT_ENDPOINT = f"{PIPELINE_BASE_URL}/detect"
+PROPAGATE_ENDPOINT = f"{PIPELINE_BASE_URL}/propagate"
+
+
+def check_service_available():
+    """Check if Pipeline service is available."""
+    try:
+        requests.get(
+            f"{PIPELINE_BASE_URL}/health".replace("/pipeline/health", "/health"),
+            timeout=2,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def encode_image_from_path(image_path):
+    """Encode image file to base64."""
+    with open(image_path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def find_frame_pair():
+    """Return a pair of frame paths for benchmark, or None if unavailable."""
+    if not TRACKING_FRAMES_DIR.exists():
+        return None
+
+    for dataset_dir in sorted(TRACKING_FRAMES_DIR.iterdir()):
+        if not dataset_dir.is_dir():
+            continue
+        frames = sorted(dataset_dir.glob("*.jpg"))
+        if len(frames) >= 2:
+            return frames[0], frames[1]
+
+    return None
+
+
+def post_detect(image_data, profile=False):
+    """POST a detect request."""
+    payload = {"image_data": image_data, "profile": profile}
+    return requests.post(DETECT_ENDPOINT, json=payload, timeout=120)
+
+
+def post_propagate(image_data, state, profile=False):
+    """POST a propagate request."""
+    payload = {"image_data": image_data, "state": state, "profile": profile}
+    return requests.post(PROPAGATE_ENDPOINT, json=payload, timeout=120)
+
+
+def summarize_profiles(profiles):
+    """Flatten nested timing dicts and average them across responses."""
+    sums = {}
+    counts = {}
+
+    def add(prefix, value):
+        if isinstance(value, dict):
+            for k, v in value.items():
+                key = f"{prefix}.{k}" if prefix else k
+                add(key, v)
+        elif isinstance(value, (int, float)):
+            sums[prefix] = sums.get(prefix, 0.0) + value
+            counts[prefix] = counts.get(prefix, 0) + 1
+
+    for profile in profiles:
+        add("", profile)
+
+    return {k: sums[k] / counts[k] for k in sums}
+
+
+class TestPipelineParallelBenchmark:
+    """Benchmark parallel detect/propagate calls using the Pipeline API."""
+
+    @pytest.fixture(autouse=True)
+    def check_service(self):
+        """Check if Pipeline service is running before each test."""
+        if not check_service_available():
+            pytest.skip(
+                "Pipeline service not available. Run: docker compose up -d pipeline"
+            )
+
+    def test_parallel_detect_and_propagate(self):
+        frame_pair = find_frame_pair()
+        if not frame_pair:
+            pytest.skip("Tracking frames not available for benchmark")
+
+        first_frame, second_frame = frame_pair
+        image_first = encode_image_from_path(first_frame)
+        image_second = encode_image_from_path(second_frame)
+
+        # Warm-up detect to get a state object for propagate.
+        warmup_resp = post_detect(image_first)
+        assert warmup_resp.status_code == 200, warmup_resp.text
+        warmup_state = warmup_resp.json().get("state")
+        assert warmup_state is not None, "Warm-up detect missing state"
+
+        # Benchmark 12 parallel detect calls.
+        start = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=12) as executor:
+            detect_futures = [
+                executor.submit(post_detect, image_first, True) for _ in range(12)
+            ]
+            detect_results = [f.result() for f in detect_futures]
+        detect_elapsed = time.perf_counter() - start
+
+        detect_profiles = []
+        for idx, resp in enumerate(detect_results):
+            assert resp.status_code == 200, f"Detect {idx} failed: {resp.text}"
+            result = resp.json()
+            assert result.get("state") is not None, f"Detect {idx} missing state"
+            if result.get("profile"):
+                detect_profiles.append(result["profile"])
+
+        # Benchmark 12 parallel propagate calls.
+        start = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=12) as executor:
+            prop_futures = [
+                executor.submit(post_propagate, image_second, warmup_state, True)
+                for _ in range(12)
+            ]
+            prop_results = [f.result() for f in prop_futures]
+        propagate_elapsed = time.perf_counter() - start
+
+        propagate_profiles = []
+        for idx, resp in enumerate(prop_results):
+            assert resp.status_code == 200, f"Propagate {idx} failed: {resp.text}"
+            result = resp.json()
+            assert result.get("state") is not None, f"Propagate {idx} missing state"
+            if result.get("profile"):
+                propagate_profiles.append(result["profile"])
+
+        print(
+            f"Parallel detect (12 calls): {detect_elapsed:.2f}s | "
+            f"Parallel propagate (12 calls): {propagate_elapsed:.2f}s"
+        )
+        print("Target (eventual): both <= 30s")
+
+        if detect_profiles:
+            detect_summary = summarize_profiles(detect_profiles)
+            print("Detect profile (avg, seconds):")
+            for key in sorted(detect_summary.keys()):
+                print(f"  {key}: {detect_summary[key]:.3f}")
+
+        if propagate_profiles:
+            propagate_summary = summarize_profiles(propagate_profiles)
+            print("Propagate profile (avg, seconds):")
+            for key in sorted(propagate_summary.keys()):
+                print(f"  {key}: {propagate_summary[key]:.3f}")

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,6 @@
-docker compose down pipeline && docker compose up -d pipeline && sleep 10 && docker compose run --rm pipeline uv run python -m pytest tests/test_tracking.py -vs
+docker compose down pipeline \
+	&& docker compose up -d pipeline \
+	&& curl --retry 30 --retry-all-errors --retry-delay 1 --silent --show-error http://localhost:8800/health \
+	&& curl --retry 120 --retry-all-errors --retry-delay 2 --max-time 5 --silent --show-error --output /dev/null http://localhost:8805/ \
+	&& curl --retry 120 --retry-all-errors --retry-delay 2 --max-time 5 --silent --show-error --output /dev/null http://localhost:8803/ \
+	&& docker compose run --rm pipeline uv run python -m pytest tests/test_benchmark_parallel.py -vs


### PR DESCRIPTION
## What

Adds opt-in performance profiling to the detect/propagate pipeline and replaces the slow plantcv color analysis with a fast custom implementation, plus a parallel benchmark test.

### Profiling instrumentation
- Requests can set a `profile` flag; when set, the response includes a nested `profile` dict of per-stage wall-clock timings (decode, SAM3 calls, mask refinement, stats, cleaning, etc.).
- A shared `timed(timings, key)` context manager (`app/utils.py`) and an accumulating `_timed_accumulate()` (`app/plant/stats.py`) collect timings without repeated `perf_counter()` boilerplate.

### Fast color analysis
- Replaces `pcv.analyze.color(colorspaces="all")` with `_color_means_for_masked_region`, which computes the same per-channel mean stats (RGB / HSV / LAB + circular hue) directly with numpy.
- Crops to the mask bounding box and reduces over masked pixels only, avoiding full-frame colour-space conversions. Output keys/scales match the previous plantcv conventions so downstream consumers are unaffected.

### Tooling
- New `tests/test_benchmark_parallel.py`: fires 12 concurrent detect + 12 concurrent propagate calls and prints the averaged profile breakdown.
- `test.sh` now waits for the `sam3` (8805) and `embeddings` (8803) services to be ready — not just the pipeline `/health` — before running pytest, fixing a cold-start race that produced spurious 500s.

## Benchmark (12 parallel calls each, local)
- Parallel detect: ~38s · Parallel propagate: ~31s
- Time is dominated by the SAM3 model calls (`sam3_plant_detect` ~17.8s, `detect_pots_sam3` ~8.0s); the new color path is cheap (`color_analysis` ~0.012s avg).

## Test
`bash test.sh` → `1 passed` once services are warm.